### PR TITLE
chore: add changeset for initial release

### DIFF
--- a/.changeset/initial-release.md
+++ b/.changeset/initial-release.md
@@ -1,0 +1,7 @@
+---
+"@chatcops/core": minor
+"@chatcops/server": minor
+"@chatcops/widget": minor
+---
+
+Initial release of ChatCops packages with AI provider abstraction, server adapters, and embeddable chat widget.


### PR DESCRIPTION
## Summary
- Adds changeset for initial v0.1.0 release of all 3 packages

Required for the release workflow to publish to npm when dev → production PR is merged.