### PR TITLE
fix: build once before typecheck in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,11 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Build core (required by server)
-        run: pnpm --filter @chatcops/core build
+      - name: Build
+        run: pnpm -r build
 
       - name: Typecheck
         run: pnpm -r typecheck
 
       - name: Test
         run: pnpm test
-
-      - name: Build
-        run: pnpm -r build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,17 +26,14 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Build core (required by server)
-        run: pnpm --filter @chatcops/core build
+      - name: Build
+        run: pnpm -r build
 
       - name: Typecheck
         run: pnpm -r typecheck
 
       - name: Test
         run: pnpm test
-
-      - name: Build
-        run: pnpm -r build
 
       - name: Create Release PR or Publish
         id: changesets


### PR DESCRIPTION
## Summary
- Move build step before typecheck, remove duplicate core build
- Addresses Copilot review feedback on PR #2

## Test plan
- [x] CI will validate on this PR