### PR TITLE
fix: switch to npm trusted publishing (OIDC)

### DIFF
--- a/.changeset/inline-mode.md
+++ b/.changeset/inline-mode.md
@@ -1,0 +1,5 @@
+---
+"@chatcops/widget": minor
+---
+
+Add inline display mode to the widget. Set `mode: 'inline'` with a `container` element to render the chat panel directly inside a page element instead of as a floating popup. Export `Widget` class for creating multiple independent instances.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Test
         run: pnpm test
 
+      - name: Ensure npm supports OIDC
+        run: npm install -g npm@latest
+
       - name: Create Release PR or Publish
         id: changesets
         uses: changesets/action@v1
@@ -43,7 +46,6 @@ jobs:
           title: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Deploy website to Vercel
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
## Summary
- Remove NPM_TOKEN from release workflow (blocks OIDC)
- Add npm upgrade step to ensure OIDC support (requires npm >= 11.5.1)
- Trusted publishers configured on npmjs.com for all 3 packages