### PR TITLE
fix: add repository field for npm provenance

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,11 @@
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codercops/chatcops",
+    "directory": "packages/core"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -50,6 +50,11 @@
     "vitest": "^3.0.0",
     "@types/express": "^5.0.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codercops/chatcops",
+    "directory": "packages/server"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -31,6 +31,11 @@
     "vitest": "^3.0.0",
     "happy-dom": "^16.0.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codercops/chatcops",
+    "directory": "packages/widget"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- Add `repository` field to all 3 package.json files
- Required for npm OIDC trusted publishing provenance validation
- Without this, npm rejects publish with: `"repository.url" is "", expected to match "https://github.com/codercops/chatcops"`