### PR TITLE
chore: add changeset for package READMEs

### DIFF
--- a/.changeset/add-package-readmes.md
+++ b/.changeset/add-package-readmes.md
@@ -1,0 +1,7 @@
+---
+"@chatcops/core": patch
+"@chatcops/server": patch
+"@chatcops/widget": patch
+---
+
+Add README.md to all packages with install instructions, usage examples, and API reference


### PR DESCRIPTION
Adds a patch changeset for @chatcops/core, @chatcops/server, and @chatcops/widget so the READMEs get published to npm on the next release.