### PR TITLE
ci: run CI on PRs targeting production branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [dev]
   pull_request:
-    branches: [dev]
+    branches: [dev, production]
 
 jobs:
   typecheck-test-build:


### PR DESCRIPTION
Adds `production` to CI pull_request trigger branches so the Changesets Version Packages PR gets CI checks instead of hanging on 'Waiting for status to be reported'.