### PR TITLE
feat: add message retry and regenerate functionality

### DIFF
--- a/.changeset/retry-regenerate-messages.md
+++ b/.changeset/retry-regenerate-messages.md
@@ -1,0 +1,7 @@
+---
+'@chatcops/core': minor
+'@chatcops/server': minor
+'@chatcops/widget': minor
+---
+
+Add retry and regenerate support for widget conversations, including assistant message regeneration, retryable error bubbles, and server-side conversation updates for regenerate requests.

--- a/packages/core/src/conversation/manager.ts
+++ b/packages/core/src/conversation/manager.ts
@@ -47,6 +47,15 @@ export class ConversationManager {
     return conversation?.messages ?? [];
   }
 
+  async removeMessage(conversationId: string, messageId: string): Promise<void> {
+    const conversation = await this.store.get(conversationId);
+    if (!conversation) return;
+
+    conversation.messages = conversation.messages.filter((message) => message.id !== messageId);
+    conversation.updatedAt = Date.now();
+    await this.store.save(conversation);
+  }
+
   async deleteConversation(id: string): Promise<void> {
     await this.store.delete(id);
   }

--- a/packages/core/tests/conversation/manager.test.ts
+++ b/packages/core/tests/conversation/manager.test.ts
@@ -89,4 +89,18 @@ describe('ConversationManager', () => {
     const messages = await manager.getMessages('nope');
     expect(messages).toHaveLength(0);
   });
+
+  it('removes a message by id', async () => {
+    const manager = new ConversationManager();
+    const userMessage = makeMessage('user', 'Hello');
+    const assistantMessage = makeMessage('assistant', 'Hi there!');
+
+    await manager.addMessage('conv-remove', userMessage);
+    await manager.addMessage('conv-remove', assistantMessage);
+    await manager.removeMessage('conv-remove', assistantMessage.id);
+
+    const messages = await manager.getMessages('conv-remove');
+    expect(messages).toHaveLength(1);
+    expect(messages[0].id).toBe(userMessage.id);
+  });
 });

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -17,6 +17,8 @@ export interface ChatCopsServerConfig {
 export const chatRequestSchema = z.object({
   conversationId: z.string().min(1).max(128),
   message: z.string().min(1).max(10000),
+  messageId: z.string().min(1).max(128).optional(),
+  regenerate: z.boolean().optional(),
   pageContext: z.object({
     url: z.string().url(),
     title: z.string().max(500),

--- a/packages/server/src/handler.ts
+++ b/packages/server/src/handler.ts
@@ -46,22 +46,38 @@ export function createChatHandler(config: ChatCopsServerConfig) {
     }
 
     // Get or create conversation
-    const conversation = await conversations.getOrCreate(req.conversationId);
+    await conversations.getOrCreate(req.conversationId);
+
+    if (req.regenerate) {
+      const existingMessages = await conversations.getMessages(req.conversationId);
+      const lastAssistant = [...existingMessages].reverse().find((message) => message.role === 'assistant');
+      if (lastAssistant) {
+        await conversations.removeMessage(req.conversationId, lastAssistant.id);
+      }
+    }
+
+    const conversationMessages = await conversations.getMessages(req.conversationId);
 
     // Track analytics
-    if (analytics && conversation.messages.length === 0) {
+    if (analytics && conversationMessages.length === 0) {
       analytics.track('conversation:started', { conversationId: req.conversationId });
     }
     analytics?.track('message:sent', { conversationId: req.conversationId });
 
-    // Add user message
-    const userMessage: ChatMessage = {
-      id: crypto.randomUUID(),
-      role: 'user',
-      content: req.message,
-      timestamp: Date.now(),
-    };
-    await conversations.addMessage(req.conversationId, userMessage);
+    // Add user message unless this is a regenerate request or a retry of the same message
+    const hasExistingUserMessage = req.messageId
+      ? conversationMessages.some((message) => message.id === req.messageId)
+      : false;
+
+    if (!req.regenerate && !hasExistingUserMessage) {
+      const userMessage: ChatMessage = {
+        id: req.messageId ?? crypto.randomUUID(),
+        role: 'user',
+        content: req.message,
+        timestamp: Date.now(),
+      };
+      await conversations.addMessage(req.conversationId, userMessage);
+    }
 
     // Build system prompt
     let systemPrompt = config.systemPrompt;

--- a/packages/server/tests/handler.test.ts
+++ b/packages/server/tests/handler.test.ts
@@ -1,23 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@chatcops/core', () => {
+  type ChatMessage = {
+    id: string;
+    role: 'user' | 'assistant' | 'system';
+    content: string;
+    timestamp: number;
+    metadata?: Record<string, unknown>;
+  };
+
+  type Conversation = {
+    id: string;
+    messages: ChatMessage[];
+    metadata?: Record<string, unknown>;
+    createdAt: number;
+    updatedAt: number;
+  };
+
   class ConversationManager {
-    private readonly conversations = new Map<
-      string,
-      {
-        id: string;
-        messages: Array<{
-          id: string;
-          role: 'user' | 'assistant' | 'system';
-          content: string;
-          timestamp: number;
-          metadata?: Record<string, unknown>;
-        }>;
-        metadata?: Record<string, unknown>;
-        createdAt: number;
-        updatedAt: number;
-      }
-    >();
+    private readonly conversations = new Map<string, Conversation>();
 
     async getOrCreate(id: string) {
       const existing = this.conversations.get(id);
@@ -26,7 +27,7 @@ vi.mock('@chatcops/core', () => {
       }
 
       const now = Date.now();
-      const conversation = {
+      const conversation: Conversation = {
         id,
         messages: [],
         createdAt: now,
@@ -36,21 +37,22 @@ vi.mock('@chatcops/core', () => {
       return conversation;
     }
 
-    async addMessage(conversationId: string, message: {
-      id: string;
-      role: 'user' | 'assistant' | 'system';
-      content: string;
-      timestamp: number;
-      metadata?: Record<string, unknown>;
-    }) {
+    async addMessage(conversationId: string, message: ChatMessage) {
       const conversation = await this.getOrCreate(conversationId);
       conversation.messages.push(message);
       conversation.updatedAt = Date.now();
+      return conversation;
     }
 
     async getMessages(conversationId: string) {
       const conversation = await this.getOrCreate(conversationId);
       return [...conversation.messages];
+    }
+
+    async removeMessage(conversationId: string, messageId: string) {
+      const conversation = await this.getOrCreate(conversationId);
+      conversation.messages = conversation.messages.filter((message) => message.id !== messageId);
+      conversation.updatedAt = Date.now();
     }
   }
 
@@ -333,6 +335,54 @@ describe('createChatHandler', () => {
       },
     });
   });
+
+  it('removes the previous assistant message before regenerating', async () => {
+    const receivedMessages: Array<Array<{ role: string; content: string }>> = [];
+
+    mockedCreateProvider.mockResolvedValue({
+      name: 'test-provider',
+      async *chat(params) {
+        receivedMessages.push(
+          params.messages.map((message) => ({
+            role: message.role,
+            content: message.content,
+          }))
+        );
+        yield receivedMessages.length === 1 ? 'First reply' : 'Regenerated reply';
+      },
+      async chatSync() {
+        return '';
+      },
+    });
+
+    const { handleChat } = createChatHandler({
+      provider: { type: 'claude', apiKey: 'test-key' },
+      systemPrompt: 'Test',
+      cors: '*',
+    });
+
+    for await (const _chunk of handleChat({
+      conversationId: 'conv-regenerate',
+      message: 'Hello there',
+      messageId: 'user-1',
+    })) {
+      // Drain initial response.
+    }
+
+    for await (const _chunk of handleChat({
+      conversationId: 'conv-regenerate',
+      message: 'Hello there',
+      messageId: 'user-1',
+      regenerate: true,
+    })) {
+      // Drain regenerated response.
+    }
+
+    expect(receivedMessages).toEqual([
+      [{ role: 'user', content: 'Hello there' }],
+      [{ role: 'user', content: 'Hello there' }],
+    ]);
+  });
 });
 
 describe('chatRequestSchema', () => {
@@ -356,6 +406,21 @@ describe('chatRequestSchema', () => {
       locale: 'en',
     });
     expect(result.success).toBe(true);
+  });
+
+  it('accepts regenerate metadata', () => {
+    const result = chatRequestSchema.safeParse({
+      conversationId: 'conv-1',
+      message: 'Hello',
+      messageId: 'msg-1',
+      regenerate: true,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.messageId).toBe('msg-1');
+      expect(result.data.regenerate).toBe(true);
+    }
   });
 
   it('rejects empty conversationId', () => {
@@ -403,6 +468,7 @@ describe('chatRequestSchema', () => {
     if (result.success) {
       expect(result.data.pageContext).toBeUndefined();
       expect(result.data.locale).toBeUndefined();
+      expect(result.data.regenerate).toBeUndefined();
     }
   });
 });

--- a/packages/widget/src/api/types.ts
+++ b/packages/widget/src/api/types.ts
@@ -1,6 +1,8 @@
 export interface WidgetChatRequest {
   conversationId: string;
   message: string;
+  messageId?: string;
+  regenerate?: boolean;
   pageContext?: {
     url: string;
     title: string;

--- a/packages/widget/src/dom/messages.ts
+++ b/packages/widget/src/dom/messages.ts
@@ -1,7 +1,7 @@
 import { renderMarkdown } from '../markdown.js';
 
 const RETRY_ICON = '<svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path d="M17.65 6.35A7.96 7.96 0 0012 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08A5.99 5.99 0 0112 18c-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"/></svg>';
-const REGENERATE_ICON = '<svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path d="M17.65 6.35A7.96 7.96 0 0012 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08A5.99 5.99 0 0112 18c-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"/></svg>';
+const REGENERATE_ICON = '<svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46A7.93 7.93 0 0020 12c0-4.42-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74A7.93 7.93 0 004 12c0 4.42 3.58 8 8 8v3l4-4-4-4v3z"/></svg>';
 
 export type MessageStatus = 'streaming' | 'complete' | 'error';
 export type MessageErrorType = 'rate_limit' | 'network' | 'provider_error' | 'timeout';

--- a/packages/widget/src/dom/messages.ts
+++ b/packages/widget/src/dom/messages.ts
@@ -1,16 +1,33 @@
 import { renderMarkdown } from '../markdown.js';
 
+const RETRY_ICON = '<svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path d="M17.65 6.35A7.96 7.96 0 0012 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08A5.99 5.99 0 0112 18c-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"/></svg>';
+const REGENERATE_ICON = '<svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path d="M17.65 6.35A7.96 7.96 0 0012 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08A5.99 5.99 0 0112 18c-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"/></svg>';
+
+export type MessageStatus = 'streaming' | 'complete' | 'error';
+export type MessageErrorType = 'rate_limit' | 'network' | 'provider_error' | 'timeout';
+
 export interface MessageData {
   id: string;
   role: 'user' | 'assistant';
   content: string;
+  status?: MessageStatus;
+  errorType?: MessageErrorType;
+}
+
+export interface MessageActions {
+  onRetry?: (messageId: string) => void;
+  onRegenerate?: (messageId: string) => void;
+  retryLabel?: string;
+  regenerateLabel?: string;
 }
 
 export class Messages {
   private container: HTMLDivElement;
   private typingEl: HTMLDivElement | null = null;
+  private actions?: MessageActions;
 
-  constructor(parent: HTMLElement) {
+  constructor(parent: HTMLElement, actions?: MessageActions) {
+    this.actions = actions;
     this.container = document.createElement('div');
     this.container.className = 'cc-messages';
     parent.appendChild(this.container);
@@ -18,19 +35,16 @@ export class Messages {
 
   addMessage(msg: MessageData): HTMLDivElement {
     this.removeTyping();
-    const el = document.createElement('div');
-    el.className = `cc-message cc-message-${msg.role}`;
-    el.dataset.id = msg.id;
-    el.innerHTML = msg.role === 'assistant' ? renderMarkdown(msg.content) : this.escapeHtml(msg.content);
+    const el = this.createMessageElement(msg);
     this.container.appendChild(el);
     this.scrollToBottom();
     return el;
   }
 
-  updateMessage(id: string, content: string, isAssistant: boolean): void {
-    const el = this.container.querySelector(`[data-id="${id}"]`) as HTMLDivElement | null;
+  updateMessage(msg: MessageData): void {
+    const el = this.container.querySelector(`[data-id="${msg.id}"]`) as HTMLDivElement | null;
     if (el) {
-      el.innerHTML = isAssistant ? renderMarkdown(content) : this.escapeHtml(content);
+      this.renderMessageElement(el, msg);
       this.scrollToBottom();
     }
   }
@@ -56,12 +70,124 @@ export class Messages {
     this.typingEl = null;
   }
 
+  removeMessage(id: string): void {
+    const el = this.container.querySelector(`[data-id="${id}"]`) as HTMLDivElement | null;
+    el?.remove();
+  }
+
+  clearRegenerateButtons(): void {
+    this.container.querySelectorAll('.cc-message-regenerate').forEach((button) => button.remove());
+    this.cleanupEmptyActionContainers();
+  }
+
+  showRegenerateButton(messageId: string): void {
+    this.clearRegenerateButtons();
+
+    if (!this.actions?.onRegenerate) return;
+
+    const msgEl = this.container.querySelector(`[data-id="${messageId}"]`) as HTMLDivElement | null;
+    if (!msgEl || !msgEl.classList.contains('cc-message-assistant')) return;
+
+    const actions = this.ensureActionsContainer(msgEl);
+    actions.appendChild(this.createActionButton({
+      className: 'cc-message-regenerate',
+      label: this.actions.regenerateLabel ?? 'Regenerate',
+      icon: REGENERATE_ICON,
+      onClick: () => this.actions?.onRegenerate?.(messageId),
+    }));
+  }
+
   setVisible(visible: boolean): void {
     this.container.classList.toggle('cc-hidden', !visible);
   }
 
   private scrollToBottom(): void {
     this.container.scrollTop = this.container.scrollHeight;
+  }
+
+  private createMessageElement(msg: MessageData): HTMLDivElement {
+    const el = document.createElement('div');
+    this.renderMessageElement(el, msg);
+    return el;
+  }
+
+  private renderMessageElement(el: HTMLDivElement, msg: MessageData): void {
+    el.className = `cc-message cc-message-${msg.role}`;
+    el.dataset.id = msg.id;
+
+    if (msg.status) {
+      el.dataset.status = msg.status;
+    } else {
+      delete el.dataset.status;
+    }
+
+    if (msg.errorType) {
+      el.dataset.errorType = msg.errorType;
+    } else {
+      delete el.dataset.errorType;
+    }
+
+    el.innerHTML = '';
+
+    const content = document.createElement('div');
+    content.className = 'cc-message-content';
+    content.innerHTML = msg.role === 'assistant' ? renderMarkdown(msg.content) : this.escapeHtml(msg.content);
+    el.appendChild(content);
+
+    const actions = this.createActionsContainer(msg);
+    if (actions) {
+      el.appendChild(actions);
+    }
+  }
+
+  private createActionsContainer(msg: MessageData): HTMLDivElement | null {
+    if (msg.status !== 'error' || !this.actions?.onRetry) {
+      return null;
+    }
+
+    const actions = document.createElement('div');
+    actions.className = 'cc-message-actions';
+    actions.appendChild(this.createActionButton({
+      className: 'cc-message-retry',
+      label: this.actions.retryLabel ?? 'Retry',
+      icon: RETRY_ICON,
+      onClick: () => this.actions?.onRetry?.(msg.id),
+    }));
+    return actions;
+  }
+
+  private ensureActionsContainer(msgEl: HTMLDivElement): HTMLDivElement {
+    const existing = msgEl.querySelector('.cc-message-actions') as HTMLDivElement | null;
+    if (existing) {
+      return existing;
+    }
+
+    const actions = document.createElement('div');
+    actions.className = 'cc-message-actions';
+    msgEl.appendChild(actions);
+    return actions;
+  }
+
+  private cleanupEmptyActionContainers(): void {
+    this.container.querySelectorAll('.cc-message-actions').forEach((container) => {
+      if (!container.hasChildNodes()) {
+        container.remove();
+      }
+    });
+  }
+
+  private createActionButton(options: {
+    className: string;
+    label: string;
+    icon: string;
+    onClick: () => void;
+  }): HTMLButtonElement {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = options.className;
+    button.innerHTML = `${options.icon}<span>${this.escapeHtml(options.label)}</span>`;
+    button.addEventListener('click', options.onClick);
+    return button;
   }
 
   private escapeHtml(text: string): string {

--- a/packages/widget/src/dom/panel.ts
+++ b/packages/widget/src/dom/panel.ts
@@ -1,4 +1,4 @@
-import { Messages, type MessageData } from './messages.js';
+import { Messages, type MessageActions, type MessageData } from './messages.js';
 import { Input } from './input.js';
 
 const BOT_ICON = `<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"/></svg>`;
@@ -15,6 +15,7 @@ export interface PanelOptions {
   };
   placeholder: string;
   footerText: string;
+  messageActions?: MessageActions;
   onSend: (text: string) => void;
   onClose: () => void;
 }
@@ -77,7 +78,7 @@ export class Panel {
     } else {
       this.messagesContainer = this.el;
     }
-    this.messages = new Messages(this.messagesContainer);
+    this.messages = new Messages(this.messagesContainer, options.messageActions);
 
     // Input
     this.input = new Input(this.el, {

--- a/packages/widget/src/i18n.ts
+++ b/packages/widget/src/i18n.ts
@@ -15,6 +15,8 @@ export interface WidgetLocaleStrings {
   preChatSubmit: string;
   preChatRequired: string;
   preChatInvalidEmail: string;
+  retryButton: string;
+  regenerateButton: string;
 }
 
 const en: WidgetLocaleStrings = {
@@ -34,6 +36,8 @@ const en: WidgetLocaleStrings = {
   preChatSubmit: 'Start Chat',
   preChatRequired: 'This field is required',
   preChatInvalidEmail: 'Please enter a valid email',
+  retryButton: 'Retry',
+  regenerateButton: 'Regenerate',
 };
 
 const locales: Record<string, WidgetLocaleStrings> = { en };

--- a/packages/widget/src/storage.ts
+++ b/packages/widget/src/storage.ts
@@ -4,6 +4,8 @@ interface StoredConversation {
     id: string;
     role: 'user' | 'assistant';
     content: string;
+    status?: 'streaming' | 'complete' | 'error';
+    errorType?: 'rate_limit' | 'network' | 'provider_error' | 'timeout';
     timestamp: number;
   }>;
   updatedAt: number;

--- a/packages/widget/src/storage.ts
+++ b/packages/widget/src/storage.ts
@@ -32,7 +32,13 @@ export class ConversationStorage {
 
   save(conversation: StoredConversation): void {
     try {
-      localStorage.setItem(this.key, JSON.stringify(conversation));
+      const filtered = {
+        ...conversation,
+        messages: conversation.messages
+          .filter((m) => m.status !== 'error')
+          .map(({ status, ...message }) => message),
+      };
+      localStorage.setItem(this.key, JSON.stringify(filtered));
     } catch {
       // Storage full or unavailable
     }

--- a/packages/widget/src/styles/widget.css
+++ b/packages/widget/src/styles/widget.css
@@ -256,6 +256,9 @@
   overflow-wrap: break-word;
   font-size: 14px;
   line-height: 1.5;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .cc-message-user {
@@ -305,6 +308,56 @@
 .cc-message ul, .cc-message ol {
   padding-left: 20px;
   margin: 4px 0;
+}
+
+.cc-message-actions {
+  display: flex;
+  align-items: center;
+}
+
+.cc-message-retry,
+.cc-message-regenerate {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  background: transparent;
+  border: 1px solid var(--cc-border);
+  border-radius: 6px;
+  color: var(--cc-text-secondary);
+  font-family: var(--cc-font);
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, opacity 0.15s ease;
+}
+
+.cc-message-retry:hover,
+.cc-message-regenerate:hover {
+  background: var(--cc-bg-input);
+  color: var(--cc-text);
+}
+
+.cc-message-retry svg,
+.cc-message-regenerate svg {
+  fill: currentColor;
+}
+
+.cc-message-regenerate {
+  opacity: 0;
+}
+
+.cc-message:hover .cc-message-regenerate {
+  opacity: 1;
+}
+
+.cc-message-retry {
+  border-color: #ef4444;
+  color: #ef4444;
+}
+
+.cc-message-retry:hover {
+  background: rgba(239, 68, 68, 0.1);
+  color: #ef4444;
 }
 
 /* Typing indicator */

--- a/packages/widget/src/widget.ts
+++ b/packages/widget/src/widget.ts
@@ -7,7 +7,8 @@ import { ConversationStorage } from './storage.js';
 import { applyTheme } from './theme.js';
 import { getWidgetLocale, type WidgetLocaleStrings } from './i18n.js';
 import { PreChatForm } from './dom/prechat-form.js';
-import type { MessageData } from './dom/messages.js';
+import type { WidgetChatRequest } from './api/types.js';
+import type { MessageData, MessageErrorType } from './dom/messages.js';
 
 export interface PreChatField {
   name: string;
@@ -73,6 +74,10 @@ type WidgetEventType =
   | 'leadCaptured'
   | 'preChatSubmit';
 type WidgetEventHandler = (...args: unknown[]) => void;
+type SendRequestOptions = {
+  regenerate?: boolean;
+  userMessageId?: string;
+};
 
 export class Widget {
   private config: WidgetConfig;
@@ -89,6 +94,7 @@ export class Widget {
   private userData?: Record<string, string>;
   private userDataSent = false;
   private isStreaming = false;
+  private retryRequests = new Map<string, SendRequestOptions>();
   private eventHandlers = new Map<WidgetEventType, Set<WidgetEventHandler>>();
   private containerEl?: HTMLElement;
 
@@ -151,6 +157,16 @@ export class Widget {
       },
       placeholder: this.config.placeholder ?? this.locale.inputPlaceholder,
       footerText: this.locale.poweredBy,
+      messageActions: {
+        onRetry: (messageId) => {
+          void this.handleRetry(messageId);
+        },
+        onRegenerate: (messageId) => {
+          void this.handleRegenerate(messageId);
+        },
+        retryLabel: this.locale.retryButton,
+        regenerateLabel: this.locale.regenerateButton,
+      },
       onSend: (text) => this.handleSend(text),
       onClose: () => this.close(),
     });
@@ -177,6 +193,8 @@ export class Widget {
     } else {
       this.showChatView();
     }
+
+    this.showLatestRegenerateButton();
 
     // Welcome bubble — popup mode only
     if (!this.isInline && this.config.welcomeBubble) {
@@ -326,44 +344,117 @@ export class Widget {
     this.config.onMessage?.(userMsg);
     this.emit('message', userMsg);
 
+    await this.sendToServer(text, { userMessageId: userMsg.id });
+  }
+
+  private async handleRetry(errorMessageId: string): Promise<void> {
+    if (this.isStreaming) return;
+
+    const errorIndex = this.messages.findIndex((message) => message.id === errorMessageId);
+    if (errorIndex === -1) return;
+
+    const retryRequest = this.retryRequests.get(errorMessageId);
+    let userMessage = retryRequest?.userMessageId
+      ? this.messages.find((message) => message.id === retryRequest.userMessageId)
+      : undefined;
+
+    if (!userMessage) {
+      for (let i = errorIndex - 1; i >= 0; i--) {
+        if (this.messages[i].role === 'user') {
+          userMessage = this.messages[i];
+          break;
+        }
+      }
+    }
+
+    if (!userMessage) return;
+
+    this.panel.messages.removeMessage(errorMessageId);
+    this.retryRequests.delete(errorMessageId);
+    this.messages = this.messages.filter((message) => message.id !== errorMessageId);
+
+    await this.sendToServer(userMessage.content, {
+      regenerate: retryRequest?.regenerate,
+      userMessageId: retryRequest?.userMessageId ?? userMessage.id,
+    });
+  }
+
+  private async handleRegenerate(assistantMessageId: string): Promise<void> {
+    if (this.isStreaming) return;
+
+    const assistantIndex = this.messages.findIndex((message) => message.id === assistantMessageId);
+    if (assistantIndex === -1) return;
+
+    const assistantMessage = this.messages[assistantIndex];
+    if (assistantMessage.role !== 'assistant') return;
+
+    const userMessage = this.findUserMessageForAssistant(assistantIndex);
+    if (!userMessage) return;
+
+    this.panel.messages.clearRegenerateButtons();
+    this.panel.messages.removeMessage(assistantMessageId);
+    this.retryRequests.delete(assistantMessageId);
+    this.messages = this.messages.filter((message) => message.id !== assistantMessageId);
+
+    await this.sendToServer(userMessage.content, {
+      regenerate: true,
+      userMessageId: userMessage.id,
+    });
+  }
+
+  private async sendToServer(text: string, options: SendRequestOptions = {}): Promise<void> {
+    if (this.isStreaming) return;
+
     this.isStreaming = true;
     this.panel.input.setDisabled(true);
+    this.panel.messages.clearRegenerateButtons();
     this.panel.messages.showTyping();
 
     const assistantMsg: MessageData = {
       id: crypto.randomUUID(),
       role: 'assistant',
       content: '',
+      status: 'streaming',
     };
 
-    const pageContext = this.config.pageContext !== false
-      ? { url: window.location.href, title: document.title }
-      : undefined;
-
-    const includeUserData = this.userData && !this.userDataSent;
+    const includeUserData = !!(this.userData && !this.userDataSent);
+    let firstChunk = true;
+    let requestCompleted = false;
+    let hasError = false;
 
     try {
-      let firstChunk = true;
-      for await (const chunk of this.client.sendMessage({
-        conversationId: this.conversationId,
-        message: text,
-        pageContext,
-        locale: this.config.locale,
-        ...(includeUserData ? { userData: this.userData } : {}),
-      })) {
+      for await (const chunk of this.client.sendMessage(this.createRequest(text, options, includeUserData))) {
         if (chunk.error) {
-          const errorKey = chunk.error === 'rate_limit' ? 'errorRateLimit'
-            : chunk.error === 'network' ? 'errorNetwork'
-            : 'errorGeneric';
-          assistantMsg.content = this.locale[errorKey];
+          const errorType = this.resolveErrorType(chunk.error);
+          assistantMsg.content = this.getErrorMessage(errorType);
+          assistantMsg.status = 'error';
+          assistantMsg.errorType = errorType;
+          hasError = true;
+
+          this.retryRequests.set(assistantMsg.id, {
+            regenerate: options.regenerate,
+            userMessageId: options.userMessageId,
+          });
+
           this.panel.messages.removeTyping();
-          this.panel.addMessage(assistantMsg);
-          this.config.onError?.(new Error(chunk.error));
-          this.emit('error', new Error(chunk.error));
+          if (firstChunk) {
+            this.panel.addMessage(assistantMsg);
+          } else {
+            this.panel.messages.updateMessage(assistantMsg);
+          }
+
+          this.messages.push(assistantMsg);
+
+          const error = new Error(chunk.error);
+          this.config.onError?.(error);
+          this.emit('error', error);
           break;
         }
 
-        if (chunk.done) break;
+        if (chunk.done) {
+          requestCompleted = true;
+          break;
+        }
 
         if (chunk.leadCaptured) {
           this.config.onLeadCaptured?.(chunk.leadData);
@@ -376,33 +467,137 @@ export class Widget {
             this.panel.addMessage(assistantMsg);
             firstChunk = false;
           }
+
           assistantMsg.content += chunk.content;
-          this.panel.messages.updateMessage(assistantMsg.id, assistantMsg.content, true);
+          this.panel.messages.updateMessage(assistantMsg);
         }
       }
 
-      if (assistantMsg.content) {
+      if (!hasError && !requestCompleted) {
+        requestCompleted = true;
+      }
+
+      if (!hasError && firstChunk) {
+        this.panel.messages.removeTyping();
+      }
+
+      if (!hasError && assistantMsg.content) {
+        assistantMsg.status = 'complete';
+        this.panel.messages.updateMessage(assistantMsg);
         this.messages.push(assistantMsg);
         this.config.onMessage?.(assistantMsg);
         this.emit('message', assistantMsg);
+        this.showLatestRegenerateButton();
 
         if (!this.isInline && !this.panel.isVisible) {
           this.fab?.showBadge();
         }
       }
     } catch (err) {
-      this.panel.messages.removeTyping();
       assistantMsg.content = this.locale.errorGeneric;
+      assistantMsg.status = 'error';
+      assistantMsg.errorType = 'network';
+
+      this.retryRequests.set(assistantMsg.id, {
+        regenerate: options.regenerate,
+        userMessageId: options.userMessageId,
+      });
+
+      this.panel.messages.removeTyping();
       this.panel.addMessage(assistantMsg);
-      this.config.onError?.(err instanceof Error ? err : new Error(String(err)));
+      this.messages.push(assistantMsg);
+
+      const error = err instanceof Error ? err : new Error(String(err));
+      this.config.onError?.(error);
+      this.emit('error', error);
     } finally {
-      if (includeUserData) {
+      if (includeUserData && requestCompleted) {
         this.userDataSent = true;
       }
       this.isStreaming = false;
       this.panel.input.setDisabled(false);
       this.panel.input.focus();
       this.saveHistory();
+    }
+  }
+
+  private createRequest(
+    text: string,
+    options: SendRequestOptions,
+    includeUserData: boolean
+  ): WidgetChatRequest {
+    const pageContext = this.config.pageContext !== false
+      ? { url: window.location.href, title: document.title }
+      : undefined;
+
+    return {
+      conversationId: this.conversationId,
+      message: text,
+      messageId: options.userMessageId,
+      regenerate: options.regenerate,
+      pageContext,
+      locale: this.config.locale,
+      ...(includeUserData ? { userData: this.userData } : {}),
+    };
+  }
+
+  private findUserMessageForAssistant(assistantIndex: number): MessageData | undefined {
+    for (let i = assistantIndex - 1; i >= 0; i--) {
+      if (this.messages[i].role === 'user') {
+        return this.messages[i];
+      }
+    }
+
+    return undefined;
+  }
+
+  private findLatestRegeneratableAssistant(): MessageData | undefined {
+    for (let i = this.messages.length - 1; i >= 0; i--) {
+      const message = this.messages[i];
+      if (message.id === 'welcome') {
+        continue;
+      }
+
+      if (message.role !== 'assistant' || message.status === 'error') {
+        return undefined;
+      }
+
+      return message;
+    }
+
+    return undefined;
+  }
+
+  private showLatestRegenerateButton(): void {
+    const assistantMessage = this.findLatestRegeneratableAssistant();
+    if (assistantMessage) {
+      this.panel.messages.showRegenerateButton(assistantMessage.id);
+    } else {
+      this.panel.messages.clearRegenerateButtons();
+    }
+  }
+
+  private resolveErrorType(error: string): MessageErrorType {
+    switch (error) {
+      case 'rate_limit':
+      case 'network':
+      case 'provider_error':
+      case 'timeout':
+        return error;
+      default:
+        return 'provider_error';
+    }
+  }
+
+  private getErrorMessage(errorType: MessageErrorType): string {
+    switch (errorType) {
+      case 'rate_limit':
+        return this.locale.errorRateLimit;
+      case 'network':
+      case 'timeout':
+        return this.locale.errorNetwork;
+      default:
+        return this.locale.errorGeneric;
     }
   }
 
@@ -418,6 +613,8 @@ export class Widget {
         id: m.id,
         role: m.role,
         content: m.content,
+        status: m.status,
+        errorType: m.errorType,
         timestamp: Date.now(),
       })),
       updatedAt: Date.now(),

--- a/packages/widget/tests/dom/messages.test.ts
+++ b/packages/widget/tests/dom/messages.test.ts
@@ -32,7 +32,7 @@ describe('Messages', () => {
 
   it('updates an existing message', () => {
     messages.addMessage({ id: '3', role: 'assistant', content: 'Hello' });
-    messages.updateMessage('3', 'Hello world', true);
+    messages.updateMessage({ id: '3', role: 'assistant', content: 'Hello world' });
     const msg = parent.querySelector('[data-id="3"]');
     expect(msg?.textContent).toContain('Hello world');
   });
@@ -62,5 +62,64 @@ describe('Messages', () => {
     messages.addMessage({ id: '5', role: 'user', content: '<script>alert("xss")</script>' });
     const msg = parent.querySelector('.cc-message-user');
     expect(msg?.innerHTML).not.toContain('<script>');
+  });
+
+  it('renders a retry button for error messages', () => {
+    messages = new Messages(parent, {
+      onRetry: () => undefined,
+      retryLabel: 'Retry now',
+    });
+
+    messages.addMessage({
+      id: 'error-1',
+      role: 'assistant',
+      content: 'Something went wrong.',
+      status: 'error',
+      errorType: 'provider_error',
+    });
+
+    const retryButton = parent.querySelector('.cc-message-retry');
+    expect(retryButton).toBeTruthy();
+    expect(retryButton?.textContent).toContain('Retry now');
+  });
+
+  it('does not render a retry button for complete assistant messages', () => {
+    messages = new Messages(parent, {
+      onRetry: () => undefined,
+    });
+
+    messages.addMessage({
+      id: 'assistant-1',
+      role: 'assistant',
+      content: 'All good.',
+      status: 'complete',
+    });
+
+    expect(parent.querySelector('.cc-message-retry')).toBeNull();
+  });
+
+  it('removes a message by id', () => {
+    messages.addMessage({ id: 'remove-1', role: 'assistant', content: 'Remove me' });
+
+    messages.removeMessage('remove-1');
+
+    expect(parent.querySelector('[data-id="remove-1"]')).toBeNull();
+  });
+
+  it('shows a regenerate button on the selected assistant message', () => {
+    messages = new Messages(parent, {
+      onRegenerate: () => undefined,
+      regenerateLabel: 'Try again',
+    });
+
+    messages.addMessage({ id: 'assistant-a', role: 'assistant', content: 'First', status: 'complete' });
+    messages.addMessage({ id: 'assistant-b', role: 'assistant', content: 'Second', status: 'complete' });
+
+    messages.showRegenerateButton('assistant-b');
+
+    expect(parent.querySelector('[data-id="assistant-a"] .cc-message-regenerate')).toBeNull();
+    const regenerateButton = parent.querySelector('[data-id="assistant-b"] .cc-message-regenerate');
+    expect(regenerateButton).toBeTruthy();
+    expect(regenerateButton?.textContent).toContain('Try again');
   });
 });

--- a/packages/widget/tests/widget.test.ts
+++ b/packages/widget/tests/widget.test.ts
@@ -1,9 +1,33 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Widget } from '../src/widget.js';
 
-describe('Widget lead capture handling', () => {
+type WidgetInternals = {
+  client: {
+    sendMessage: ReturnType<typeof vi.fn>;
+  };
+  shadow: ShadowRoot;
+  messages: Array<{
+    id: string;
+    role: 'user' | 'assistant';
+    content: string;
+    status?: 'streaming' | 'complete' | 'error';
+    errorType?: 'rate_limit' | 'network' | 'provider_error' | 'timeout';
+  }>;
+  isStreaming: boolean;
+  handleSend(text: string): Promise<void>;
+  handleRetry(messageId: string): Promise<void>;
+  handleRegenerate(messageId: string): Promise<void>;
+};
+
+function getInternals(widget: Widget): WidgetInternals {
+  return widget as unknown as WidgetInternals;
+}
+
+describe('Widget', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
+    localStorage.clear();
+    sessionStorage.clear();
   });
 
   it('fires the leadCaptured callback and event when the stream includes lead data', async () => {
@@ -23,11 +47,127 @@ describe('Widget lead capture handling', () => {
       yield { done: true };
     });
 
-    (widget as unknown as { client: { sendMessage: typeof sendMessage } }).client.sendMessage = sendMessage;
+    getInternals(widget).client.sendMessage = sendMessage;
 
-    await (widget as unknown as { handleSend(text: string): Promise<void> }).handleSend('Hello');
+    await getInternals(widget).handleSend('Hello');
 
     expect(onLeadCaptured).toHaveBeenCalledWith({ email: 'lead@example.com' });
     expect(eventHandler).toHaveBeenCalledWith({ email: 'lead@example.com' });
+  });
+
+  it('retries a failed message with the same user message id and replaces the error bubble', async () => {
+    const widget = new Widget({
+      apiUrl: 'https://api.test/chat',
+    });
+    widget.init();
+
+    const sendMessage = vi.fn()
+      .mockImplementationOnce(async function* () {
+        yield { error: 'provider_error' };
+      })
+      .mockImplementationOnce(async function* () {
+        yield { content: 'Recovered response' };
+        yield { done: true };
+      });
+
+    getInternals(widget).client.sendMessage = sendMessage;
+
+    await getInternals(widget).handleSend('Retry me');
+
+    const firstUserMessage = getInternals(widget).messages.find((message) => message.role === 'user');
+    const errorMessage = getInternals(widget).messages.find((message) => message.status === 'error');
+
+    expect(firstUserMessage).toBeTruthy();
+    expect(errorMessage).toBeTruthy();
+    expect(getInternals(widget).shadow.querySelector('.cc-message-retry')).toBeTruthy();
+
+    await getInternals(widget).handleRetry(errorMessage!.id);
+
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(sendMessage.mock.calls[0]?.[0]).toMatchObject({
+      message: 'Retry me',
+      messageId: firstUserMessage?.id,
+    });
+    expect(sendMessage.mock.calls[1]?.[0]).toMatchObject({
+      message: 'Retry me',
+      messageId: firstUserMessage?.id,
+    });
+
+    expect(getInternals(widget).messages.some((message) => message.id === errorMessage!.id)).toBe(false);
+    expect(getInternals(widget).messages.at(-1)).toMatchObject({
+      role: 'assistant',
+      content: 'Recovered response',
+      status: 'complete',
+    });
+  });
+
+  it('regenerates the last assistant response and sends the regenerate flag', async () => {
+    const widget = new Widget({
+      apiUrl: 'https://api.test/chat',
+    });
+    widget.init();
+
+    const sendMessage = vi.fn()
+      .mockImplementationOnce(async function* () {
+        yield { content: 'First response' };
+        yield { done: true };
+      })
+      .mockImplementationOnce(async function* () {
+        yield { content: 'Second response' };
+        yield { done: true };
+      });
+
+    getInternals(widget).client.sendMessage = sendMessage;
+
+    await getInternals(widget).handleSend('Regenerate me');
+
+    const userMessage = getInternals(widget).messages.find((message) => message.role === 'user');
+    const assistantMessage = getInternals(widget).messages.at(-1);
+
+    expect(assistantMessage).toMatchObject({
+      role: 'assistant',
+      content: 'First response',
+      status: 'complete',
+    });
+    expect(getInternals(widget).shadow.querySelector('.cc-message-regenerate')).toBeTruthy();
+
+    await getInternals(widget).handleRegenerate(assistantMessage!.id);
+
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(sendMessage.mock.calls[1]?.[0]).toMatchObject({
+      message: 'Regenerate me',
+      messageId: userMessage?.id,
+      regenerate: true,
+    });
+    expect(getInternals(widget).messages.some((message) => message.id === assistantMessage!.id)).toBe(false);
+    expect(getInternals(widget).messages.at(-1)).toMatchObject({
+      role: 'assistant',
+      content: 'Second response',
+      status: 'complete',
+    });
+  });
+
+  it('blocks retry and regenerate while streaming is active', async () => {
+    const widget = new Widget({
+      apiUrl: 'https://api.test/chat',
+    });
+    widget.init();
+
+    const sendMessage = vi.fn();
+    getInternals(widget).client.sendMessage = sendMessage;
+
+    getInternals(widget).messages.push(
+      { id: 'user-1', role: 'user', content: 'Hello' },
+      { id: 'assistant-1', role: 'assistant', content: 'Answer', status: 'complete' },
+      { id: 'assistant-err', role: 'assistant', content: 'Failed', status: 'error', errorType: 'provider_error' }
+    );
+
+    getInternals(widget).isStreaming = true;
+
+    await getInternals(widget).handleRetry('assistant-err');
+    await getInternals(widget).handleRegenerate('assistant-1');
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(getInternals(widget).messages).toHaveLength(4);
   });
 });


### PR DESCRIPTION
## Summary
- add retry buttons for error assistant messages and regenerate actions for the latest successful assistant reply
- refactor widget sending so normal send, retry, and regenerate share the same streaming path and preserve history state
- add server-side regenerate support by removing the previous assistant reply and avoiding duplicate user messages with stable message ids
- add tests for message actions, widget retry/regenerate flows, conversation removal, and regenerate handling in the server

## Verification
- corepack pnpm --filter @chatcops/widget test
- corepack pnpm --filter @chatcops/server test -- tests/handler.test.ts
- corepack pnpm --filter @chatcops/core test -- tests/conversation/manager.test.ts
- corepack pnpm -r typecheck
- corepack pnpm --filter @chatcops/core build
- corepack pnpm --filter @chatcops/widget build
- corepack pnpm --filter @chatcops/server build

Closes #18